### PR TITLE
Add try/catch on data access

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -38,7 +38,11 @@ export class State{
     Logger.trace("Fetching data");
     const name_p = t.card("name");
     let data = await t.getAll();
-    data = data.card.shared || {};
+    try {
+      data = data.card.shared || {};
+    } catch {
+      data = {};
+    }
     Logger.trace("Got data");
 
     this.is_active = data.POMORELLO_ACTIVE || this.is_active;

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,11 @@ import { Logger } from "./logger.js";
 
 window.TrelloPowerUp.initialize({
   "card-buttons": async t => {
-    const state = new State();
-    await state.fetch(t);
-
     return [
       {
         icon: pomorello_icon,
         text: "Pomorello",
-        callback: new_t => MainMenu(new_t, state)
+        callback: async new_t => MainMenu(new_t)
       }
     ];
   },

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,9 +1,10 @@
 import { Start, End } from "./update.js";
 import { Logger } from "./logger.js";
+import { State } from "./data.js";
 
 export function SetMenu(t, state) {
   Logger.trace("Showing dropdown powerup menu");
-  
+
   const short_set = {
     text: "Short Set " + "15m active, 3m break, 9m long break".replace(/ /g, '\xa0'),
     callback: new_t => Start(new_t, state, 15, 3)
@@ -23,7 +24,7 @@ export function SetMenu(t, state) {
   if (Logger.level >= 2) {
     debug_set = {
       text: "Debug Set " + "1m active, 10s break, 30s long break".replace(/ /g, '\xa0'),
-      callback: new_t => Start(new_t, state, 1, 1/6)
+      callback: new_t => Start(new_t, state, 1, 1 / 6)
     };
   }
 
@@ -49,15 +50,19 @@ export function ActionMenu(t, state) {
 
   return t.popup({
     title: "Stop a Pomodoro",
-    
+
     items: [
       kill_set
     ]
   });
 }
 
-export function MainMenu(t, state) {
+export async function MainMenu(t) {
+
   Logger.trace("Showing main menu");
+
+  const state = new State();
+  await state.fetch(t);
 
   const start = {
     text: "Start a Set",

--- a/src/update.js
+++ b/src/update.js
@@ -10,12 +10,14 @@ export async function Start(t, state, set_length_m, break_length_m) {
   state.set_length = 1000 * 60 * set_length_m;
   state.break_length = 1000 * 60 * break_length_m;
 
-  return state.sync(t);
+  const toReturn = state.sync(t);
+  t.closePopup();
+  return toReturn;
 }
 
 export async function Break(t, state) {
   Logger.trace(`Pomodoro for card ${state.name} finished.`);
-  
+
   notify(t, `Pomodoro for card ${state.name} complete.\nTime to take a break!`);
 
   state.is_active = false;
@@ -23,7 +25,9 @@ export async function Break(t, state) {
   state.start_ms = Date.now();
   state.addSet();
 
-  return state.sync(t);
+  const toReturn = state.sync(t);
+  t.closePopup();
+  return toReturn;
 }
 
 export async function End(t, state) {
@@ -35,6 +39,8 @@ export async function End(t, state) {
   state.is_break = false;
   state.start_ms = 0;
 
-  return state.sync(t);
+  const toReturn = state.sync(t);
+  t.closePopup();
+  return toReturn;
 }
 


### PR DESCRIPTION
👋Thanks for making this publicly available. Love being able to contribute to it!

Three things to check out in this PR:

1. **try/catch on data access**: An error occurs when you try `data = data.card.shared || {};` because no data has been stored on the card. This is why the Power-Up worked as expected on an existing board (that had data set so `data.card` was not undefined) and not on a fresh board. There is probably a cleaner way of catching this, but this works.
2. **card-button timing**: As it is, you're waiting to access data before returning whether or not you want to show a card button. But, that data is only needed at the point in time that a user clicks the button, right? I'd recommend moving the data access bit into the card-button callback so that you only block on it when you actually need the data. If how your button was displayed depended on the data then it would be worthwhile to wait; but because you always show the card button, no need to wait. Just get a button back ASAP.
3. **t.closePopup()**: I added in a call to close the popups whenever a user selects an option. Check out the docs on `t.closePopup` here: https://developers.trello.com/reference#t-popup

On number 1, it isn't great that the error occurring was so silent. We have a PR open internally to `console.warn` when that occurs. Hopefully that makes it easier to debug in the future.